### PR TITLE
Document nonterminal prettifying

### DIFF
--- a/scribblings/nanopass.scrbl
+++ b/scribblings/nanopass.scrbl
@@ -340,8 +340,6 @@ if the meta-variable is @racket[e] then @racket[e1], @racket[e*], @racket[e?],
 production is either of the type of the meta-variable or bottom (represented by
 @racket[#f]).
 
-
-
 Thus, Racket language forms such as @racket[let] can be represented as a
 language production as:
 

--- a/scribblings/nanopass.scrbl
+++ b/scribblings/nanopass.scrbl
@@ -198,10 +198,14 @@ The full syntax for @racket[define-language] is as follows:
                     (extended-terminal-caluse (+ terminal-clause ...)
                                               (- terminal-clause ...))
 
-                    (production-clause terminal-meta-var
-                                       non-terminal-meta-var
-                                       production-pattern
-                                       (keyword . production-pattern))
+                    (production-clause basic-production-clause
+                                       (=> basic-production-clause pretty-pattern)
+                                       (code:line basic-production-clause => pretty-pattern))
+                    
+                    (basic-production-clause terminal-meta-var
+                                             non-terminal-meta-var
+                                             production-pattern
+                                             (keyword . production-pattern))
 
                     (extended-production-clause (+ production-clause ...)
                                                 (- production-clause ...))
@@ -293,6 +297,27 @@ this non-terminal.
 an S-expression representation, language input pattern, or language output
 template.
 
+If present, a @racket[pretty-pattern] is used by the
+generated unparser. Any occurrences of metavariables in the
+@racket[pretty-pattern] are substituted with the
+corresponding subexpressions (recursively unparsed) of the
+term to be unparsed, and the substituted pattern is the
+result of unparsing. Pattern variables bound to lists can be
+spliced using ellipses. For example,
+
+@racketblock[
+(call e e* ...) => (e e* ...)
+]
+
+might cause @racket[(call f a b c)] to unparse to
+@racket[(f a b c)]. Note that non-metavariables are left alone:
+
+@racketblock[
+(app e1 e2) => (%app e1 e2)
+]
+
+will turn @racket[(app f a)] into @racket[(%app f a)].
+
 @racket[production-pattern] is an S-expression that represents a
 pattern for language, and has the following form.
 
@@ -314,6 +339,8 @@ if the meta-variable is @racket[e] then @racket[e1], @racket[e*], @racket[e?],
 @racket[(maybe meta-variable)] indicates that an element in the
 production is either of the type of the meta-variable or bottom (represented by
 @racket[#f]).
+
+
 
 Thus, Racket language forms such as @racket[let] can be represented as a
 language production as:


### PR DESCRIPTION
Addressing https://github.com/nanopass/nanopass-framework-racket/issues/39

As a side note, from reading the code it's clear that there's supposed to be a similar `->` notation for supplying a prettifier *procedure* (as in `terminals`). Indeed it is accepted but the expansion fails… I will see if I can fix it (possibly resolving https://github.com/nanopass/nanopass-framework-racket/issues/26).